### PR TITLE
Acquisition mode mapping for scienta txt reader

### DIFF
--- a/pynxtools_xps/scienta/scienta_txt.py
+++ b/pynxtools_xps/scienta/scienta_txt.py
@@ -576,7 +576,7 @@ def _change_scan_mode(acquisition_mode: str):
     the allowed values in NXmpes.
 
     """
-    mode_map = {"Fixed": "fixed", "Swept": "fixed_analyser_transmission"}
+    mode_map = {"Fixed": "fixed_energy", "Swept": "fixed_analyser_transmission"}
     if acquisition_mode in mode_map:
         return mode_map[acquisition_mode]
     return None

--- a/pynxtools_xps/scienta/scienta_txt.py
+++ b/pynxtools_xps/scienta/scienta_txt.py
@@ -576,7 +576,7 @@ def _change_scan_mode(acquisition_mode: str):
     the allowed values in NXmpes.
 
     """
-    mode_map = {"Fixed": "fixed", "Swept": "sweep"}
+    mode_map = {"Fixed": "fixed", "Swept": "fixed_analyser_transmission"}
     if acquisition_mode in mode_map:
         return mode_map[acquisition_mode]
     return None


### PR DESCRIPTION
Takes into account that `NXenergydispersion/energy_scan_mode` has an enumeration that the reader should map to.