### PR TITLE
Fix date parsing in scienta reader

### DIFF
--- a/pynxtools_xps/scienta/scienta_mappings.py
+++ b/pynxtools_xps/scienta/scienta_mappings.py
@@ -62,7 +62,7 @@ def _construct_date_time(date_string: str, time_string: str) -> Optional[str]:
             try:
                 return datetime.datetime.strptime(date_string, date_fmt)
             except ValueError as err:
-                raise ValueError("Date format not recognized") from err
+                continue
         raise ValueError("Date format not recognized")
 
     def _parse_time(time_string: str) -> datetime.time:
@@ -71,7 +71,7 @@ def _construct_date_time(date_string: str, time_string: str) -> Optional[str]:
             try:
                 return datetime.datetime.strptime(time_string, time_fmt).time()
             except ValueError as err:
-                raise ValueError("Time format not recognized") from err
+                continue
         raise ValueError("Time format not recognized")
 
     try:


### PR DESCRIPTION
This is a bug fix to the datetime parsing. If the ValueError is raised as before (inside the loop for each format that fails), the loop will not continue to the next format.