### PR TITLE
Allow .npl as a synonym for .vms files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,9 @@ The explanation section provides background knowledge on the implementation desi
 Here you can learn which specific measurement setups and file formats from technology partners pynxtools-xps currently supports.
 
 The reader decides which data parser to use based on the file extension of the files provided. For the main XPS files, the following file extensions are supported:
+
 - .ibw: [Igor Binary Wave Format](https://www.wavemetrics.com/) files, exported from [Scienta Omicron](https://scientaomicron.com/en)
+- .npl: VAMAS files, ISO standard data transfer format ([ISO 14976](https://www.iso.org/standard/24269.html)), both in regular and irregular format
 - .spe, .pro: [Phi MultiPak](https://www.phi.com/surface-analysis-equipment/genesis.html#software:multi-pak-data-reduction-software/) files, propietary format of PHI Electronics
 - .sle: [SpecsLabProdigy](https://www.specs-group.com/nc/specs/products/detail/prodigy/) files, propietary format of SPECS GmbH (1 and v4)
 - .xml: SpecsLab 2files, XML format from SPECS GmbH (v1.6)

--- a/docs/reference/vms.md
+++ b/docs/reference/vms.md
@@ -1,10 +1,10 @@
 # VAMAS ISO standard (VMS)
 
-The reader supports VAMAS (.vms) files, the ISO standard data transfer format ([ISO 14976](https://www.iso.org/standard/24269.html)) for X-ray photoelectron spectroscopy. The data can be stored both in REGULAR (i.e, with an equally spaced energy axis) as well as IRREGULAR mode. The data was measured with and exported from [SpecsLabProdigy](https://www.specs-group.com/nc/specs/products/detail/prodigy/).
+The reader supports VAMAS (.vms) files, the ISO standard data transfer format ([ISO 14976](https://www.iso.org/standard/24269.html)) for X-ray photoelectron spectroscopy. The data can be stored both in REGULAR (i.e, with an equally spaced energy axis) as well as IRREGULAR mode. The reader also allows for .npl files which are structured in the same way as .vms files.
 
 The reader for the VAMAS format can be found [here](https://github.com/FAIRmat-NFDI/pynxtools-xps/tree/main/pynxtools_xps/vms).
 
-Example data is available [here](https://github.com/FAIRmat-NFDI/pynxtools-xps/tree/main/examples/vms).
+Example data is available [here](https://github.com/FAIRmat-NFDI/pynxtools-xps/tree/main/examples/vms). The data was measured with and exported from [SpecsLabProdigy](https://www.specs-group.com/nc/specs/products/detail/prodigy/).
 
 
 ## Standard .vms data

--- a/pynxtools_xps/file_parser.py
+++ b/pynxtools_xps/file_parser.py
@@ -35,11 +35,12 @@ from pynxtools_xps.vms.vamas import VamasMapper
 class XpsDataFileParser:
     """Class intended for receiving any type of XPS data file."""
 
-    __prmt_file_ext__ = ["ibw", "pro", "spe", "sle", "txt", "vms", "xml", "xy"]
+    __prmt_file_ext__ = ["ibw", "npl", "pro", "spe", "sle", "txt", "vms", "xml", "xy"]
     __prmt_metadata_file_ext__ = ["slh"]
     __vendors__ = ["kratos", "phi", "scienta", "specs", "unkwown"]
     __prmt_vndr_cls: Dict[str, Dict] = {
         "ibw": {"scienta": MapperScienta},
+        "npl": {"unkwown": VamasMapper},
         "pro": {"phi": MapperPhi},
         "spe": {"phi": MapperPhi},
         "sle": {"specs": SleMapperSpecs},

--- a/pynxtools_xps/reader_utils.py
+++ b/pynxtools_xps/reader_utils.py
@@ -453,6 +453,7 @@ def align_name_part(name_part: str):
         ",": "",
         ".": "_",
         "-": "_",
+        ":": "_",
     }
 
     for key, val in replacements.items():


### PR DESCRIPTION
Sometimes, .vms files are saved as .npl, with the same content. See for example in this [Zenodo search](https://zenodo.org/search?q=filetype%3Anpl&l=list&p=3&s=10&sort=bestmatch).

This PR allows  .npl as a synonym for .vms files.