### PR TITLE
Update CITATION.cff version to v0.4.3 [ci skip release]

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,7 @@ authors:
     orcid: 'https://orcid.org/0000-0002-9700-4803'
 doi: TODO
 repository-code: 'https://github.com/FAIRmat-NFDI/pynxtools-xps'
-version: 0.4.2
+version: 0.4.3
 url: TODO
 keywords:
   - X-ray Photoelectron Spectroscopy


### PR DESCRIPTION
This PR updates the CITATION.cff version to v0.4.3