### PR TITLE
remove duplicated ignore-undocumented flag in example script

### DIFF
--- a/scripts/regenerate_examples_undocumented.sh
+++ b/scripts/regenerate_examples_undocumented.sh
@@ -58,7 +58,7 @@ function update_vms_examples {
   dataconverter vms_txt_export.txt eln_data_vms_txt_export.yaml --reader $READER --nxdl $NXDL --output vms_txt_export.nxs --ignore-undocumented
   cd ../data_analysis
   echo "Update data analysis example"
-  dataconverter FeO* eln.yaml --reader $READER --nxdl $NXDL --ignore-undocumented --output vms_data_analysis.nxs --ignore-undocumented
+  dataconverter FeO* eln.yaml --reader $READER --nxdl $NXDL --output vms_data_analysis.nxs --ignore-undocumented
   cd ../..
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove a duplicate flag to simplify the script.