### PR TITLE
add workflow for nomad-requirements

### DIFF
--- a/.github/workflows/nomad-requirements.yaml
+++ b/.github/workflows/nomad-requirements.yaml
@@ -1,0 +1,50 @@
+name: NOMAD dependencies compatibility
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    # Run workflow only when there are changes in pyproject.toml or dev-requirements.txt
+    # paths:
+    #   - 'pyproject.toml'
+    #   - 'dev-requirements.txt'
+
+env:
+  python-version: 3.11
+
+jobs:
+  validate_dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout pynxtools
+      uses: actions/checkout@v4
+
+    - name: Checkout NOMAD from GitLab
+      run: |
+        git clone --depth 1 --branch develop --recurse-submodules https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
+        git submodule update --init --recursive --depth 1
+    - name: Add pynxtools dependency in NOMAD test_plugins.txt
+      working-directory: ./nomad
+      run: |
+        echo "" >> test_plugins.txt
+        echo "pynxtools-xps@git+https://github.com/FAIRmat-NFDI/pynxtools-xps.git@${{ github.head_ref || github.ref_name }}" >> test_plugins.txt
+    - name: Install uv and set the python version to ${{ env.python-version }}
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ env.python-version }}
+    - name: Generate (dev-)requirements.txt from modified pyproject.toml
+      working-directory: ./nomad
+      run: |
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --extra=infrastructure --extra=parsing --output-file=requirements.txt pyproject.toml
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --extra=dev --extra=infrastructure --extra=parsing --output-file=requirements-dev.txt requirements.txt pyproject.toml
+        uv pip compile --universal -p ${{ env.python-version }} --annotation-style=line --output-file=requirements-plugins.txt --unsafe-package nomad-lab -c requirements-dev.txt test_plugins.txt
+    - name: Install NOMAD dependencies with pynxtools from current branch
+      working-directory: ./nomad
+      run: |
+        uv pip install -r requirements-plugins.txt
+      env:
+        PYTHONPATH: ""  # Ensure no pre-installed packages interfere with the test

--- a/.github/workflows/nomad-requirements.yaml
+++ b/.github/workflows/nomad-requirements.yaml
@@ -3,10 +3,10 @@ name: NOMAD dependencies compatibility
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
     # Run workflow only when there are changes in pyproject.toml or dev-requirements.txt
     # paths:
     #   - 'pyproject.toml'
@@ -27,7 +27,7 @@ jobs:
       run: |
         git clone --depth 1 --branch develop --recurse-submodules https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git nomad
         git submodule update --init --recursive --depth 1
-    - name: Add pynxtools dependency in NOMAD test_plugins.txt
+    - name: Add pynxtools-xps dependency in NOMAD test_plugins.txt
       working-directory: ./nomad
       run: |
         echo "" >> test_plugins.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "xarray>=0.20.2",
     'numpy>=1.22.4,<2.0.0',
     "pint>=0.17",
-    "pynxtools>=0.9.0",
+    "pynxtools>=0.10.1",
 ]
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "xarray>=0.20.2",
     'numpy>=1.22.4,<2.0.0',
     "pint>=0.17",
-    "pynxtools>=0.10.1",
+    "pynxtools>=0.10.0",
 ]
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary by Sourcery

Adds a CI workflow to validate dependencies compatibility with NOMAD, including pynxtools. The workflow checks out NOMAD from GitLab, adds pynxtools-xps as a dependency, generates requirements files, and installs dependencies.

CI:
- Adds a new CI workflow to validate dependencies compatibility with NOMAD.
- The workflow checks out NOMAD from GitLab, adds pynxtools-xps as a dependency, generates requirements files, and installs dependencies.