### PR TITLE
bump pynxtools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "xarray>=0.20.2",
     'numpy>=1.22.4,<2.0.0',
     "pint>=0.17",
-    "pynxtools>=0.10.0",
+    "pynxtools>=0.10.1",
 ]
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump pynxtools dependency to version 0.10.1.