### PR TITLE
remove np printoptions

### DIFF
--- a/src/pynxtools_xps/reader.py
+++ b/src/pynxtools_xps/reader.py
@@ -47,9 +47,6 @@ from pynxtools_xps.vms.vamas import VamasMapper
 
 logger = logging.getLogger("pynxtools")
 
-np.set_printoptions(threshold=sys.maxsize)
-
-
 CONVERT_DICT = {
     "unit": "@units",
     "version": "@version",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the global setting for NumPy print options (`np.set_printoptions`).