### PR TITLE
update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,100 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
   release:
     types: [published]
 
+env:
+  python-version: 3.12
+
 jobs:
+  setup:
+    name: Checkout and Install
+    runs-on: ubuntu-latest
+    outputs:
+      git_tag_version: ${{ steps.git_tag_version.outputs.version }}
+      citation_version: ${{ steps.citation_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install uv and set the python versionto ${{ env.python-version }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Git tag version
+        id: git_tag_version
+        run: |
+          GIT_TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$GIT_TAG_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Citation version
+        id: citation_version
+        run: |
+          CITATION_VERSION=$(grep '^version:' CITATION.cff | cut -d' ' -f2)
+          echo "version=$CITATION_VERSION" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Run Tests
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install uv and set the python version to ${{ env.python-version }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Install latest nomad release
+        run: |
+          uv pip install nomad-lab[infrastructure]
+      - name: Install pynxtools-xps
+        run: |
+          uv pip install -e ".[dev]"
+      - name: Install latest pynxtools release
+        run: |
+          uv pip install pynxtools
+      - name: Test with pytest
+        run: pytest tests/
+
+  compare-versions:
+    name: Compare Versions
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if versions mismatch
+        run: |
+          if [ "${{ needs.setup.outputs.git_tag_version }}" != "${{ needs.setup.outputs.citation_version }}" ]; then
+            echo "Version mismatch: Git tag is ${{ needs.setup.outputs.git_tag_version }}, CITATION.cff is ${{ needs.setup.outputs.citation_version }}"
+            exit 1
+          fi
+
+  build:
+    name: Build Package
+    needs: [compare-versions, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install uv and set the python version to ${{ env.python-version }}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Build package
+        run: uv build
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts
+          path: dist/
+
   deploy:
-    name: Upload release to PyPI
+    name: Upload to PyPI
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -25,32 +105,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install uv and use the python version 3.12
-        uses: astral-sh/setup-uv@v5
+          submodules: recursive
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: 3.12
-      
-      # Final pytest with latest pynxtools release
-      - name: Install nomad
-        run: |
-          uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
-      - name: Install pynxtools-xps
-        run: |
-          uv pip install ".[dev]"
-          uv pip install coverage coveralls
-      - name: Install latest pynxtools release
-        run: |
-          uv pip install pynxtools
-      - name: Run tests
-        run: |
-          pytest tests/.
-
-      # Build
-      - name: Install build dependencies
-        run: |
-          uv pip install build
-          git reset --hard HEAD
-      - name: Build package
-        run: python -m build
+          name: dist-artifacts
+          path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install uv and set the python versionto ${{ env.python-version }}
+      - name: Install uv and set the python version to ${{ env.python-version }}
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ env.python-version }}


### PR DESCRIPTION
## Summary by Sourcery

Refactor the GitHub Actions publish workflow for the Python package to improve build, test, and deployment processes

CI:
- Split the publish workflow into multiple jobs with distinct responsibilities
- Add version comparison step to ensure git tag and CITATION.cff versions match
- Use uv for package management and build processes

Deployment:
- Separate build and publish steps
- Use artifact upload and download for package distribution

Tests:
- Add a dedicated test job to run pytest before package deployment

Chores:
- Update to Python 3.12 as the default Python version
- Simplify nomad-lab installation