### PR TITLE
use ruff v0.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.4
+    rev: v0.12.0
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "mypy",
-    "ruff>=0.9.0",
+    "ruff>=0.12.0",
     "pytest",
     "pytest-cov",
     "pytest-timeout",


### PR DESCRIPTION
## Summary by Sourcery

Bump Ruff linter to v0.12.0 across project configurations

Enhancements:
- Update pre-commit-config.yaml to use Ruff v0.12.0
- Raise the Ruff version requirement in pyproject.toml to >=0.12.0