### PR TITLE
simplify pytest in CI/CD

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}         
       - name: Install nomad
-        if: "${{ matrix.python-version != '3.8' && matrix.python-version != '3.9'}}"
+        if: "${{ matrix.python-version != '3.9'}}"
         run: |
           uv pip install nomad-lab[infrastructure]@git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git
       - name: Install package and pynxtools master branch


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust the nomad install step to only skip Python 3.9 instead of both 3.8 and 3.9