### PR TITLE
language in docs

### DIFF
--- a/docs/explanation/contextualization.md
+++ b/docs/explanation/contextualization.md
@@ -1,4 +1,4 @@
-# How to map pieces of information to NeXus
+# How to map raw XPS data to NeXus
 
 Conceptually, mapping between representations of concepts and instance data is a key tasks in information science. The plugin pynxtools-xps implements this specifically for the file and serialization formats used within the research field of photoelectron spectroscopy (PES).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ The explanation section provides background knowledge on the implementation desi
 - [Design principles and implementation](explanation/implementation.md)
 - [NXmpes and NXxps](explanation/appdefs.md)
 - [The XPS coordinate system](explanation/coordinate_system.md)
-- [How to map pieces of information to NeXus](explanation/contextualization.md)
+- [How to map raw XPS data to NeXus](explanation/contextualization.md)
 - [Mapping of data processing performed in CasaXPS](explanation/data_processing.md)
 <!-- - - [NOMAD integration](explanation/nomad_integration.md) -->
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Rename contextualization document title and index navigation link to 'How to map raw XPS data to NeXus'